### PR TITLE
Support saved searches in inliner script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,38 @@
 # visualizations integrations tools
 
 This package currently has several functionalities:
-* Analyzes the usage of legacy visualization types in beats and integrations dashboard and indexes them into an Elasticsearch instance.
-* Inlines the visualizations in a given directory as by values panels
-* Tracks the usage of @elastic/charts vs the Lens embeddable in the Kibana code base
+
+- Analyzes the usage of legacy visualization types in beats and integrations dashboard and indexes them into an Elasticsearch instance.
+- Inlines the visualizations in a given directory as by values panels
+- Tracks the usage of @elastic/charts vs the Lens embeddable in the Kibana code base
 
 ## Prep
 
-* Have locally installed node (tested with `16.14.2`)
-* Init submodules using `git submodule update --init --recursive`
-* Install dependencies using `yarn`
+- Have locally installed node (tested with `16.14.2`)
+- Init submodules using `git submodule update --init --recursive`
+- Install dependencies using `yarn`
 
 ## Legacy vis analyzer usage
 
-* [Install go](https://go.dev/doc/install)
-* Run `ELASTICSEARCH_URL="<elasticsearch connection string>" go run index.go`
-* Import `dataview.ndjson` to have a bunch of runtime fields analyzing the structure
-
+- [Install go](https://go.dev/doc/install)
+- Run `ELASTICSEARCH_URL="<elasticsearch connection string>" go run index.go`
+- Import `dataview.ndjson` to have a bunch of runtime fields analyzing the structure
 
 ## Code analyzer usage
 
-* Run `ES="<elasticsearch connection string>" node index_kibana.js`
+- Run `ES="<elasticsearch connection string>" node index_kibana.js`
 
 ## Inliner usage
-
 
 The inliner takes all "by reference" visualizations in a given directory, uses the provided running Kibana instance to migrate them to the latest version, migrates the dashboard saved object as well, then transforms the by-reference visualizations into by-value panels, deletes the visualization json files and updates the dashboard json files.
 
 Important notes:
-* Using the inliner script will make the dashboards incompatible with earlier versions of the stack - e.g. if it has been ran with a stack version 8.2, then the new dashboard json files will only work on version 8.2 and newer
-* For old dashboards (prior to 7.10), some "agg based" visualizations might break if a target version of 7.17 or 8.0 is used. In these cases, please use at least a stack version of 8.1
 
-* Run `KIBANA="<kibana connection string>" node inline.js <path to kibana folder>` (e.g. `./integrations/packages/system/kibana/`)
-  * The kibana connection string has to include the password (for instances with security enabled) and the base path (for instances with configured base path), for example `KIBANA="http://elastic:changeme@localhost:5901/mgp"`
-* Review changes in submodule repo
-  * This review should include loading the dashboard into an instance with data to make sure everything is displayed properly
-* If everything works fine, create PR
+- Using the inliner script will make the dashboards incompatible with earlier versions of the stack - e.g. if it has been run with a stack version 8.2, then the new dashboard json files will only work on version 8.2 and newer
+- For old dashboards (prior to 7.10), some "agg based" visualizations might break if a target version of 7.17 or 8.0 is used. In these cases, please use at least a stack version of 8.1
+
+- Run `KIBANA="<kibana connection string>" node inline.js <path to kibana folder>` (e.g. `./integrations/packages/system/kibana/`)
+  - The kibana connection string has to include the password (for instances with security enabled) and the base path (for instances with configured base path), for example `KIBANA="http://elastic:changeme@localhost:5901/mgp"`
+- Review changes in submodule repo
+  - This review should include loading the dashboard into an instance with data to make sure everything is displayed properly
+- If everything works fine, create PR

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This package currently has several functionalities:
 
 ## Legacy vis analyzer usage
 
-- [Install go](https://go.dev/doc/install)
+- [Install Go](https://go.dev/doc/install)
 - Run `ELASTICSEARCH_URL="<elasticsearch connection string>" go run index.go`
 - Import `dataview.ndjson` to have a bunch of runtime fields analyzing the structure
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This package currently has several functionalities:
 
-- Analyzes the usage of legacy visualization types in beats and integrations dashboard and indexes them into an Elasticsearch instance.
-- Inlines the visualizations in a given directory as by values panels
+- Analyzes the usage of legacy visualization types in the beats and integrations dashboard and indexes them into an Elasticsearch instance.
+- Inlines the visualizations in a given directory as "by values" panels
 - Tracks the usage of @elastic/charts vs the Lens embeddable in the Kibana code base
 
 ## Prep

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package currently has several functionalities:
 
 ## Prep
 
-- Have locally installed node (tested with `16.14.2`)
+- Have locally installed `node` (tested with `16.14.2`)
 - Init submodules using `git submodule update --init --recursive`
 - Install dependencies using `yarn`
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ The inliner takes all "by reference" visualizations in a given directory, uses t
 
 Important notes:
 
-- Using the inliner script will make the dashboards incompatible with earlier versions of the stack - e.g. if it has been run with a stack version 8.2, then the new dashboard json files will only work on version 8.2 and newer
+- Using the inliner script will make the dashboards incompatible with earlier versions of the stack e.g., if it has been run with a stack version 8.2, then the new dashboard JSON files will only work on version 8.2 and above.
 - For old dashboards (prior to 7.10), some "agg based" visualizations might break if a target version of 7.17 or 8.0 is used. In these cases, please use at least a stack version of 8.1
 
 - Run `KIBANA="<kibana connection string>" node inline.js <path to kibana folder>` (e.g. `./integrations/packages/system/kibana/`)
-  - The kibana connection string has to include the password (for instances with security enabled) and the base path (for instances with configured base path), for example `KIBANA="http://elastic:changeme@localhost:5601/mgp"`
+  - The Kibana connection string has to include the password (for instances with security enabled) and the base path (for instances with configured base path), for example `KIBANA="http://elastic:changeme@localhost:5601/mgp"`
   - You may need to run `export NODE_TLS_REJECT_UNAUTHORIZED=0` if you are connecting to Kibana over TLS (https)
-- Review changes in submodule repo
+- Review changes in the submodule repo
   - This review should include loading the dashboard into an instance with data to make sure everything is displayed properly
-- If everything works fine, create PR
+- If everything works fine, create a PR

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Important notes:
 - For old dashboards (prior to 7.10), some "agg based" visualizations might break if a target version of 7.17 or 8.0 is used. In these cases, please use at least a stack version of 8.1
 
 - Run `KIBANA="<kibana connection string>" node inline.js <path to kibana folder>` (e.g. `./integrations/packages/system/kibana/`)
-  - The kibana connection string has to include the password (for instances with security enabled) and the base path (for instances with configured base path), for example `KIBANA="http://elastic:changeme@localhost:5901/mgp"`
+  - The kibana connection string has to include the password (for instances with security enabled) and the base path (for instances with configured base path), for example `KIBANA="http://elastic:changeme@localhost:5601/mgp"`
   - You may need to run `export NODE_TLS_REJECT_UNAUTHORIZED=0` if you are connecting to Kibana over TLS (https)
 - Review changes in submodule repo
   - This review should include loading the dashboard into an instance with data to make sure everything is displayed properly

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Important notes:
 
 - Run `KIBANA="<kibana connection string>" node inline.js <path to kibana folder>` (e.g. `./integrations/packages/system/kibana/`)
   - The kibana connection string has to include the password (for instances with security enabled) and the base path (for instances with configured base path), for example `KIBANA="http://elastic:changeme@localhost:5901/mgp"`
+  - You may need to run `export NODE_TLS_REJECT_UNAUTHORIZED=0` if you are connecting to Kibana over TLS (https)
 - Review changes in submodule repo
   - This review should include loading the dashboard into an instance with data to make sure everything is displayed properly
 - If everything works fine, create PR

--- a/inline.js
+++ b/inline.js
@@ -199,12 +199,7 @@ function rehydrateAttributes(attributes) {
         p.version = searchToInline.migrationVersion.search;
         p.type = "search";
         p.embeddableConfig.attributes = {
-          title: searchToInline.attributes.title,
-          description: searchToInline.attributes.description,
-          sort: searchToInline.attributes.sort,
-          columns: searchToInline.attributes.columns,
-          kibanaSavedObjectMeta:
-            searchToInline.attributes.kibanaSavedObjectMeta,
+          ...searchToInline.attributes,
           references: searchToInline.references,
         };
         delete p.panelRefName;


### PR DESCRIPTION
fix https://github.com/elastic/visualizations_integrations_tools/issues/2

Consider this effort a follow-on to https://github.com/elastic/package-spec/issues/633.

That issue was to express our preference to have saved searches be by-value in integrations.

This PR is to make it easy for package developers to inline all the saved searches in a particular integration.